### PR TITLE
Fixed tests not using ltalloc...

### DIFF
--- a/test/main.cpp
+++ b/test/main.cpp
@@ -21,12 +21,12 @@ void threadproc(int* error)
 				*error = true;
 				return;
 			}
-			p[t ^ 1] = new char[128];
-			delete[] p[t];
+			p[t ^ 1] = (char*)ltmalloc(128);
+			ltfree(p[t]);
 			p[t] = NULL;
 		}
 	for (unsigned int i = 0; i < 2 * N; i++)
-		delete[] ((char**)pp)[i];
+		ltfree(((char**)pp)[i]);
 }
 
 TEST_CASE("Original test code from the wiki", "[ltalloc]")


### PR DESCRIPTION
That's a little bit embarrassing 😅 

I disabled the global new operators with a define in cmake to make sure catch2 (the test framework) didn't use ltalloc to make its internal allocations, but I forgot to replace the news and deletes in the test code...

Good news is: the tests are running a lot faster now that they use ltalloc (I didn't expect that big a difference: on appveyor it went from ~16 millions operations per second to ~115 😮 🚀).