### PR TITLE
Clean macros

### DIFF
--- a/ltalloc.cc
+++ b/ltalloc.cc
@@ -545,6 +545,7 @@ static bool ptrie_insert(PTrie *ptrie, uintptr_t key, uintptr_t value)
 				newNode->keys[0] = key;//left prefixEnd = 0, so all following insertions will be before this node
 				newNode->childNodes[0] = (PTrieNode*)(value | 1);
 				newNode->childNodes[1] = PTRIE_NULL_NODE;
+				SPINLOCK_RELEASE(&ptrie->lock);
 				return true;
 			} else {
 				pkey = *prevKey & ~0xFF;

--- a/ltalloc.cc
+++ b/ltalloc.cc
@@ -289,7 +289,7 @@ typedef struct PTrieNode            // Compressed radix tree (patricia trie) for
 } PTrieNode;                        // 3. Tree always contains just one node with null child (i.e. all but one nodes in any possible tree are always have two children).
 #define PTRIE_NULL_NODE (PTrieNode*)(uintptr_t)1
 static PTrieNode *ptrieRoot = PTRIE_NULL_NODE, *ptrieFreeNodesList = NULL, *ptrieNewAllocatedPage = NULL;
-static volatile int ptrieLock = 0;
+static LTALLOC_SPINLOCK_TYPE ptrieLock = 0;
 
 static uintptr_t ptrie_lookup(uintptr_t key)
 {
@@ -522,7 +522,7 @@ typedef struct alignas(CACHE_LINE_SIZE) ChunkSm//chunk of smallest blocks of siz
 
 typedef struct alignas(CACHE_LINE_SIZE)//align needed to prevent cache line sharing between adjacent classes accessed from different threads
 {
-	volatile int lock;
+	LTALLOC_SPINLOCK_TYPE lock;
 	unsigned int freeBlocksInLastChunk;
 	char *lastChunk;//Chunk or ChunkSm
 	union {
@@ -545,7 +545,7 @@ static thread_local ThreadCache threadCache[NUMBER_OF_SIZE_CLASSES];// = {{0}};
 
 static struct
 {
-	volatile int lock;
+	LTALLOC_SPINLOCK_TYPE lock;
 	void *freeChunk;
 	size_t size;
 } pad = {0, NULL, 0};

--- a/ltalloc.h
+++ b/ltalloc.h
@@ -11,6 +11,7 @@ void*  ltcalloc(size_t, size_t);
 void*  ltmemalign(size_t, size_t);
 void   ltsqueeze(size_t); /*return memory to system (see README.md)*/
 size_t ltmsize(void*);
+void   ltonthreadexit();
 #ifdef __cplusplus
 }
 #endif


### PR DESCRIPTION
The diff a is little bit messy because I moved a lot of stuff around, but here is the gist of it:
- all the macros are overridable (they're defined only if not already defined), and there is a system to include you own config header at the beginning of the file to override what you want
- all the platform specific bits are now wrapped inside a macro (all the `#ifdef WIN32/GNUC` in the main code are gone)
- all the macros are documented (at least a little bit)

This was a lot harder to do than I expected 😅, especially the parts with the virtual memory functions. But I'm pretty happy with the result, it should be very easy to port to new platforms now.

The main macros are: `LTALLOC_VMALLOC`, `LTALLOC_VMFREE`, and `LTALLOC_VMALLOC_MIN_SIZE`.
If the plaform supports it, there are two more macros that you can define:
 - `LTALLOC_VMSIZE`, which is meant to return size of a previous virtual mem allocation (if not available, eg. on Linux, ltalloc will store the sizes of the allocations internally in a ptrie).
- `LTALLOC_VMALLOC_ALIGNED`, which allocates virtual memory with a specific alignment (Windows/Linux don't have a function for that, but some consoles do), and if not available, ltalloc has a slower method to make sure `LTALLOC_VMALLOC` end up returning a pointer with the right alignment.